### PR TITLE
Add product listing and detail pages

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ProductController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): View
+    {
+        $products = Product::latest()->paginate(10); // Fetch latest products, paginated
+        return view('products.index', compact('products'));
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id): View
+    {
+        $product = Product::findOrFail($id); // Find product by ID or fail (404)
+        return view('products.show', compact('product'));
+    }
+}

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -14,6 +14,7 @@
             <flux:navlist variant="outline">
                 <flux:navlist.group :heading="__('Platform')" class="grid">
                     <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:navlist.item>
+                    <flux:navlist.item icon="shopping-bag" :href="route('products.index')" :current="request()->routeIs('products.index') || request()->routeIs('products.show')" wire:navigate>{{ __('Products') }}</flux:navlist.item>
                 </flux:navlist.group>
             </flux:navlist>
 

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,0 +1,47 @@
+<x-layouts.app>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Products') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brand</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Price</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($products as $product)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $product->id }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                            <a href="{{ route('products.show', $product->id) }}" class="text-indigo-600 hover:text-indigo-900">{{ $product->name }}</a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $product->brand }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">${{ number_format($product->price, 2) }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">No products found.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="mt-4">
+                        {{ $products->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-layouts.app>

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -1,0 +1,44 @@
+<x-layouts.app>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $product->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <a href="{{ route('products.index') }}" class="text-indigo-600 hover:text-indigo-900 mb-4 inline-block">&larr; Back to Products</a>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div>
+                            @if($product->image_url)
+                                <img src="{{ $product->image_url }}" alt="{{ $product->name }}" class="w-full h-auto object-cover rounded-lg shadow-md mb-4">
+                            @else
+                                <div class="w-full h-64 bg-gray-200 flex items-center justify-center rounded-lg shadow-md mb-4">
+                                    <span class="text-gray-500">No Image Available</span>
+                                </div>
+                            @endif
+                        </div>
+                        <div>
+                            <h3 class="text-2xl font-semibold mb-2">{{ $product->name }}</h3>
+                            <p class="text-gray-600 text-sm mb-1"><strong>Brand:</strong> {{ $product->brand }}</p>
+                            <p class="text-2xl font-bold text-indigo-600 my-2">${{ number_format($product->price, 2) }}</p>
+                            <p class="text-gray-700 mb-4">{{ $product->description }}</p>
+
+                            <h4 class="font-semibold mt-4 mb-2">Specifications:</h4>
+                            <ul class="list-disc list-inside text-gray-700 space-y-1">
+                                <li><strong>Screen Size:</strong> {{ $product->screen_size }}</li>
+                                <li><strong>RAM:</strong> {{ $product->ram }}</li>
+                                <li><strong>Storage:</strong> {{ $product->storage }}</li>
+                                <li><strong>Color:</strong> {{ $product->color }}</li>
+                                <li><strong>Operating System:</strong> {{ $product->operating_system }}</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
+use App\Http\Controllers\ProductController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -18,5 +19,9 @@ Route::middleware(['auth'])->group(function () {
     Volt::route('settings/password', 'settings.password')->name('settings.password');
     Volt::route('settings/appearance', 'settings.appearance')->name('settings.appearance');
 });
+
+// Product Routes
+Route::get('/products', [ProductController::class, 'index'])->name('products.index');
+Route::get('/product/{id}', [ProductController::class, 'show'])->name('products.show');
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/ProductPageTest.php
+++ b/tests/Feature/ProductPageTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductPageTest extends TestCase
+{
+    use RefreshDatabase; // Automatically reset the database for each test
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Create a user and authenticate
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    /** @test */
+    public function products_page_loads_successfully_and_displays_products()
+    {
+        // Arrange: Create some products
+        $products = Product::factory(3)->create();
+
+        // Act: Visit the products page
+        $response = $this->get(route('products.index'));
+
+        // Assert: Page loads successfully (status 200)
+        $response->assertOk();
+
+        // Assert: Products are visible on the page
+        foreach ($products as $product) {
+            $response->assertSee($product->name);
+            $response->assertSee($product->brand);
+            // Check for the link to the product's show page
+            $response->assertSee(route('products.show', $product->id));
+        }
+    }
+
+    /** @test */
+    public function product_show_page_displays_correct_product_details()
+    {
+        // Arrange: Create a product
+        $product = Product::factory()->create();
+
+        // Act: Visit the product's show page
+        $response = $this->get(route('products.show', $product->id));
+
+        // Assert: Page loads successfully
+        $response->assertOk();
+
+        // Assert: Product details are visible
+        $response->assertSee($product->name);
+        $response->assertSee($product->brand);
+        $response->assertSee($product->description);
+        $response->assertSee(number_format($product->price, 2)); // Ensure price is formatted as in the view
+    }
+
+    /** @test */
+    public function clicking_product_link_on_index_page_navigates_to_show_page()
+    {
+        // Arrange: Create a product
+        $product = Product::factory()->create();
+
+        // Act: Visit the products index page, then click the link to the product.
+        // We don't actually "click" in feature tests, but we can simulate the navigation.
+        $response = $this->get(route('products.index'));
+        $response->assertSee(route('products.show', $product->id)); // Ensure the link is present
+
+        // Follow the link (simulate user clicking)
+        $showResponse = $this->get(route('products.show', $product->id));
+
+        // Assert: The show page is loaded successfully and shows product name
+        $showResponse->assertOk();
+        $showResponse->assertSee($product->name);
+    }
+
+    /** @test */
+    public function accessing_non_existent_product_returns_404()
+    {
+        // Arrange: A non-existent product ID
+        $nonExistentProductId = 99999; // Assuming this ID won't exist
+
+        // Act: Visit the product's show page with the non-existent ID
+        $response = $this->get(route('products.show', $nonExistentProductId));
+
+        // Assert: A 404 Not Found status is returned
+        $response->assertNotFound();
+    }
+
+    /** @test */
+    public function products_page_has_pagination()
+    {
+        // Arrange: Create more products than items per page (controller uses ->paginate(10))
+        Product::factory(15)->create();
+
+        // Act: Visit the products page
+        $response = $this->get(route('products.index'));
+
+        // Assert: Page loads successfully
+        $response->assertOk();
+
+        // Assert: Pagination links are present
+        // This is a basic check, you might need more specific selectors if using custom pagination views
+        $response->assertSee('Previous'); // Common text in Laravel pagination
+        $response->assertSee('Next');     // Common text in Laravel pagination
+    }
+}


### PR DESCRIPTION
This commit introduces new functionality for displaying products:

- A product listing page at `/products` that shows a paginated table of all products, with links to individual product detail pages.
- A product detail page at `/product/{id}` that displays comprehensive information about a selected product.

Key changes include:
- `ProductController` with `index` and `show` methods.
- Blade views `products/index.blade.php` and `products/show.blade.php`.
- Routes defined in `routes/web.php` for `/products` and `/product/{id}`.
- A navigation link "Products" added to the application sidebar.
- Feature tests (`ProductPageTest.php`) to cover the new pages, including successful loading, data display, navigation, 404 handling for non-existent products, and pagination.

The existing `Product` model and factory were utilized, and the database seeder already included product seeding.