### PR TITLE
Here's the rewritten message:

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -20,16 +20,6 @@
 
             <flux:spacer />
 
-            <flux:navlist variant="outline">
-                <flux:navlist.item icon="folder-git-2" href="https://github.com/laravel/livewire-starter-kit" target="_blank">
-                {{ __('Repository') }}
-                </flux:navlist.item>
-
-                <flux:navlist.item icon="book-open-text" href="https://laravel.com/docs/starter-kits#livewire" target="_blank">
-                {{ __('Documentation') }}
-                </flux:navlist.item>
-            </flux:navlist>
-
             <!-- Desktop User Menu -->
             @auth
             <flux:dropdown class="hidden lg:block" position="bottom" align="start">


### PR DESCRIPTION
Remove Repository and Documentation links from sidebar

This commit removes the `flux:navlist` component that displayed the 'Repository' and 'Documentation' links in your application sidebar.

The links were located in `resources/views/components/layouts/app/sidebar.blade.php`.